### PR TITLE
fix: Insert sql value for primary keys

### DIFF
--- a/dbmeta/db_utils.go
+++ b/dbmeta/db_utils.go
@@ -181,37 +181,33 @@ func GenerateInsertSQL(dbTable DbTableMeta, namedParams bool) (string, error) {
 
 	pastFirst := false
 	for _, col := range dbTable.Columns() {
-		if !col.IsAutoIncrement() {
-			if pastFirst {
-				buf.WriteString(", ")
-			}
-
-			buf.WriteString(fmt.Sprintf(" %s", col.Name()))
-			pastFirst = true
+		if pastFirst {
+			buf.WriteString(", ")
 		}
+
+		buf.WriteString(fmt.Sprintf(" %s", col.Name()))
+		pastFirst = true
 	}
 	buf.WriteString(") values ( ")
 
 	pastFirst = false
 	pos := 1
 	for i, col := range dbTable.Columns() {
-		if !col.IsAutoIncrement() {
-			if pastFirst {
-				buf.WriteString(", ")
-			}
-
-			param := fmt.Sprintf("$%d", i+1)
-			if namedParams {
-				param = fmt.Sprintf("@%s", col.Name())
-			}
-			if col.IsPrimaryKey() {
-				param = "default"
-			}
-
-			buf.WriteString(fmt.Sprintf("%s", param))
-			pos++
-			pastFirst = true
+		if pastFirst {
+			buf.WriteString(", ")
 		}
+
+		param := fmt.Sprintf("$%d", i+1)
+		if namedParams {
+			param = fmt.Sprintf("@%s", col.Name())
+		}
+		if col.IsAutoIncrement() {
+			param = "default"
+		}
+
+		buf.WriteString(fmt.Sprintf("%s", param))
+		pos++
+		pastFirst = true
 	}
 
 	buf.WriteString(" )")

--- a/dbmeta/meta_postgres.go
+++ b/dbmeta/meta_postgres.go
@@ -48,7 +48,7 @@ func LoadPostgresMeta(db *sql.DB, sqlType, sqlDatabase, tableName string) (DbTab
 		colInfo, ok := colInfo[v.Name()]
 		if ok {
 			nullable = colInfo.IsNullable == "YES"
-			isAutoIncrement = colInfo.IsIdentity == "YES"
+			isAutoIncrement = colInfo.IsIdentity == "YES" || colInfo.HasDefaultNextval
 			isPrimaryKey = colInfo.PrimaryKey
 
 			if colInfo.ColumnDefault != nil {


### PR DESCRIPTION
Fix an issue where the value for primary keys was always set to default. This prevented the posibility to set primary keys such as uuid that did not have a default value. Now only auto incremented columns will be set to default.